### PR TITLE
Add getting_started translation

### DIFF
--- a/ja/doc/getting_started/getting_started.rst
+++ b/ja/doc/getting_started/getting_started.rst
@@ -1,27 +1,27 @@
-Getting Started
+はじめに
 ===============
 
-This tutorial will install MoveIt and create a workspace sandbox to run the tutorials and example robot.
+本チュートリアルでは，MoveItをインストールし，チュートリアルを実行するためのワークスペースを構築します．
 
-Install ROS and Catkin
+ROSとCatkinをインストールする
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`Install ROS Melodic <http://wiki.ros.org/melodic/Installation/Ubuntu>`_.
-It is easy to miss steps when going through the ROS installation tutorial. If you run into errors in the next few steps, a good place to start is to go back and make sure you have installed ROS correctly.
+`Install ROS Melodic <http://wiki.ros.org/melodic/Installation/Ubuntu>`_ からROS Melodic のインストールを行いましょう.
+ROSのインストールではミスが起きがちです．もし下記手順の中でうまく行かない部分がある場合にはリンクに戻り，ROSがきちんとインストールされていることを確認してください．
 
-Once you have ROS installed, make sure you have the most up to date packages: ::
+ROSのインストールが完了したら，パッケージのアップデートを行いましょう． ::
 
   rosdep update
   sudo apt-get update
   sudo apt-get dist-upgrade
 
-Install `catkin <http://wiki.ros.org/catkin>`_ the ROS build system: ::
+次に，ROSのビルドシステムである `catkin <http://wiki.ros.org/catkin>`_ のインストールを行います． ::
 
   sudo apt-get install ros-melodic-catkin python-catkin-tools
 
-Create A Catkin Workspace and Download MoveIt Source
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-These tutorials rely on the master branch of MoveIt, which requires a build from source.
-You will need to have a `catkin <http://wiki.ros.org/catkin>`_ workspace setup: ::
+Catkinワークスペースの構築とMoveItのソースコードのダウンロード
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+チュートリアルはMoveItのmasterブランチのソースコードに基づいており，ソースコードからのビルドが必要です．
+まずは `catkin <http://wiki.ros.org/catkin>`_ ワークスペースのセットアップから行いましょう． ::
 
   mkdir -p ~/ws_moveit/src
   cd ~/ws_moveit/src
@@ -30,44 +30,40 @@ You will need to have a `catkin <http://wiki.ros.org/catkin>`_ workspace setup: 
   wstool merge -t . https://raw.githubusercontent.com/ros-planning/moveit/master/moveit.rosinstall
   wstool update -t .
 
-Download Example Code
-^^^^^^^^^^^^^^^^^^^^^
-
-To easily follow along with these tutorials, you will need a **ROBOT_moveit_config** package. The default demo robot is the Panda arm from Franka Emika. To get a working **panda_moveit_config** package, we recommend you install from source.
-
-Within your `catkin <http://wiki.ros.org/catkin>`_ workspace, download the tutorials as well as the ``panda_moveit_config`` package: ::
+ソースコード例のダウンロード
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+これから先のチュートリアルを行っていくにあたり， **ROBOT_moveit_config** パッケージ（ **ROBOT** の部分はそれぞれのロボットの名前が入ります）が必要になります．デフォルトのデモ用ロボットとして Franka Emika社の「Panda」を利用します．もし **panda_moveit_config** パッケージを利用するなら，ソースコードからのインストールをおすすめします．
+作成した `catkin <http://wiki.ros.org/catkin>`_ ワークスペース下に ``panda_moveit_config`` パッケージと本チュートリアルをダウンロードしましょう． ::
 
   cd ~/ws_moveit/src
   git clone https://github.com/ros-planning/moveit_tutorials.git -b master
   git clone https://github.com/ros-planning/panda_moveit_config.git -b melodic-devel
 
-.. note:: For now we will use a pre-generated ``panda_moveit_config`` package but later we will learn how to make our own in the `MoveIt Setup Assistant tutorial <../setup_assistant/setup_assistant_tutorial.html>`_.
+.. note:: ここでは予め作成しておいた ``panda_moveit_config`` パッケージを利用しますが， 後ほどオリジナルロボット用のパッケージの作成方法を `MoveItセットアップアシスタントチュートリアル <../setup_assistant/setup_assistant_tutorial.html>`_ にて紹介します.
 
-Build your Catkin Workspace
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The following will install from Debian any package dependencies not already in your workspace: ::
+Catkinワークスペースをビルドする
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+まず，下記コマンドでワークスペース内のパッケージが依存するDebianパッケージをインストールしましょう． ::
 
   cd ~/ws_moveit/src
   rosdep install -y --from-paths . --ignore-src --rosdistro melodic
 
-The next command will configure your catkin workspace: ::
+次に，catkinワークスペースの設定を行い，ビルドします． ::
 
   cd ~/ws_moveit
   catkin config --extend /opt/ros/${ROS_DISTRO} --cmake-args -DCMAKE_BUILD_TYPE=Release
   catkin build
 
-Source the catkin workspace: ::
+最後にcatkinワークスペースへのPATH通しを行いましょう． ::
 
   source ~/ws_moveit/devel/setup.bash
 
-Optional: add the previous command to your ``.bashrc``: ::
+オプション：下記コマンドを実行しておくと毎回端末を開く際にPATH通しをする必要がなくなります．::
 
    echo 'source ~/ws_moveit/devel/setup.bash' >> ~/.bashrc
 
-.. note:: Sourcing the ``setup.bash`` automatically in your ``~/.bashrc`` is
-   not required and often skipped by advanced users who use more than one
-   catkin workspace at a time, but we recommend it for simplicity.
+.. note:: 上記の ``setup.bash`` を ``~/.bashrc`` で読み込ませるのは必須ではありません．特に，複数のcatkinワークスペースを使用している場合は行いません．なるべく簡単にセットアップを行うためにここでは紹介しました．
 
-Next Step
+次のステップ
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`Visualize a robot with the interactive motion planning plugin for RViz <../quickstart_in_rviz/quickstart_in_rviz_tutorial.html>`_
+`RViz用のインタラクティブなモーションプランニングプラグインとロボットの可視化 <../quickstart_in_rviz/quickstart_in_rviz_tutorial.html>`_


### PR DESCRIPTION
### Description
Add `ja/doc/getting_started.rst` translation.

### For checking
```
$ ./ja/build_locally.sh
```
And the browser shows the `ja/build/html/index.html` page.
So, please check if the translation of `ja/doc/getting_started.html` is good.