### PR TITLE
Update to use utf-8 encoding

### DIFF
--- a/ja/_scripts/tutorialformatter.py
+++ b/ja/_scripts/tutorialformatter.py
@@ -81,6 +81,11 @@ from docutils.parsers.rst.directives import flag, unchanged
 from docutils.statemachine import string2lines
 from pygments.lexers import get_lexer_for_filename
 
+# For Encoding 
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 class TutorialFormatterDirective(rst.Directive):
     has_content = False
     final_argument_whitespace = True


### PR DESCRIPTION
### Description
When you write comments in an example source code to visualize it on sphinx document, you could only use ascii codes.
This PR will change that encoding to utf-8.
This change is necessary to use Japanese and any other languages.

### Attention
This fix is necessary for every Japanese translation.
That is why, if the build test be passed, I will merge this PR without review.