### PR TITLE
Add move group python interface translation

### DIFF
--- a/ja/doc/move_group_python_interface/move_group_python_interface_tutorial.rst
+++ b/ja/doc/move_group_python_interface/move_group_python_interface_tutorial.rst
@@ -41,7 +41,7 @@ RViz上で, 下記のことができているか確認します:
 
 Pythonコードの中身
 ----------------------------------------------
-Note: 今回のpythonコードはまとめて :codedir:`チュートリアルのGitHubレポジトリはここ<move_group_python_interface/scripts/move_group_python_interface_tutorial.py>` で見られます．
+Note: 今回のpythonコードはまとめて :codedir:`チュートリアルのGitHubレポジトリ<move_group_python_interface/scripts/move_group_python_interface_tutorial.py>` で見られます．
 
 .. tutorial-formatter:: ./scripts/move_group_python_interface_tutorial.py
 

--- a/ja/doc/move_group_python_interface/move_group_python_interface_tutorial.rst
+++ b/ja/doc/move_group_python_interface/move_group_python_interface_tutorial.rst
@@ -1,55 +1,50 @@
-Move Group Python Interface
+Move Group Python インタフェース
 ================================================
 .. image:: move_group_python_interface.png
    :width: 700px
 
-One of the simplest MoveIt user interfaces is through the Python-based Move Group Interface. These wrappers
-provide functionality for most operations that the average user will likely need,
-specifically setting joint or pose goals, creating motion plans, moving the
-robot, adding objects into the environment and attaching/detaching objects from
-the robot.
+MoveItのユーザーインタフェースの利用する際の最も簡単な方法は，Pythonから"Move Group"インタフェースを使用する方法です．これらのラッパーはどんなユーザーにも必要と思われる，特に最終的なジョイントや姿勢の設定や動作計画，障害物のある環境構築，ロボットに物体を付け外し，とほとんどの制御の機能を提供してくれます．
 
-Watch this quick `YouTube video demo <https://youtu.be/3MA5ebXPLsc>`_ to see the power of the Move Group Python interface!
+こちらの動画 `YouTube video demo <https://youtu.be/3MA5ebXPLsc>`_ を観て，Move Group Python インタフェースで何ができるか確認しましょう!
 
-Getting Started
+準備
 ---------------
-If you haven't already done so, make sure you've completed the steps in `Getting Started <../getting_started/getting_started.html>`_.
+もしまだ済ましていなければ，まず `Getting Started <../getting_started/getting_started.html>`_ から始めてください．
 
-Start RViz and MoveGroup node
------------------------------
-Open two shells. Start RViz and wait for everything to finish loading in the first shell: ::
+RViz と MoveGroup ノードの起動
+-----------------------------------------------------------------
+Shellを２つ立ち上げ，一方はRVizを起動しすべて完了するまで待ちます: ::
 
   roslaunch panda_moveit_config demo.launch
 
-Now run the Python code directly in the other shell using ``rosrun``.
-Note in some instances you may need to make the python script executable: ::
+もう一方のshellでは，``rosrun`` を用いてPythonコードを直接走らせます．またpythonスクリプトを実行可能にする必要があるかもしれません: ::
 
  rosrun moveit_tutorials move_group_python_interface_tutorial.py
 
-Expected Output
+今回のゴール
 ---------------
-In RViz, we should be able to see the following:
+RViz上で, 下記のことができているか確認します:
 
-Press *<enter>* in the shell terminal where you ran the ``rosrun`` command in between each step
- #. The robot plans and moves its arm to the joint goal.
- #. The robot plans a path to a pose goal.
- #. The robot plans a Cartesian path.
- #. The robot displays the Cartesian path plan again.
- #. The robot executes the Cartesian path plan.
- #. A box appears at the location of the Panda end effector.
- #. The box changes colors to indicate that it is now attached.
- #. The robot plans and executes a Cartesian path with the box attached.
- #. The box changes colors again to indicate that it is now detached.
- #. The box disappears.
+一つ前の章の ``rosrun`` を走らせたターミナルのshellで *<enter>* を押して，下記の各々のステップに進んでください．
+ #. ロボットの腕の動きが計画されており，ゴールジョイントまで移動すること
+ #. ロボットのゴール姿勢までの経路が計画されていること
+ #. ロボットがCartesianで経路が計画されていること
+ #. ロボットが再度Cartesian経路で計画されていること
+ #. ロボットがそのCartesian経路で実行されていること
+ #. Pandaのエンドエフェクタの位置に立方体が構築されていること
+ #. 立方体が取り付けられていることを示すために，その色が変わっていること
+ #. 立方体が取り付けられたロボットがCartesian経路で計画/実行されていること
+ #. 立方体が取り外されたことを示すために，色が変わっていること
+ #. 立方体が消えていること
 
-The Entire Code
----------------
-Note: the entire code can be seen :codedir:`here in the tutorials GitHub repository<move_group_python_interface/scripts/move_group_python_interface_tutorial.py>`.
+Pythonコードの中身
+----------------------------------------------
+アナウンス: 今回のpythonコードはまとめて :codedir:`チュートリアルのGitHubレポジトリはここ<move_group_python_interface/scripts/move_group_python_interface_tutorial.py>` で見られます．
 
 .. tutorial-formatter:: ./scripts/move_group_python_interface_tutorial.py
 
-The Launch File
+Launch ファイル
 ---------------
-The entire launch file is :codedir:`here<move_group_python_interface/launch/move_group_python_interface_tutorial.launch>`
-on GitHub. All the code in this tutorial can be run from the
-``moveit_tutorials`` package that you have as part of your MoveIt setup.
+今回のLaunchファイルはGitHubの :codedir:`ここ<move_group_python_interface/launch/move_group_python_interface_tutorial.launch>`
+にあります．このチュートリアルで用いられたコードはMoveItのセットアップのうちの
+``moveit_tutorials`` パッケージから走らせることができます．

--- a/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -90,10 +90,10 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## 運動学モデルと現在の関節の情報を提供してくれます
     robot = moveit_commander.RobotCommander()
 
-    ## オブジェクト `PlanningSceneInterface`_ を生成します．これはロボットを取り巻く内部環境を理解するために必要な情報を得る・設定する・変更するのに必要な遠隔インタフェースを提供してくれます:
+    ## オブジェクト `PlanningSceneInterface`_ を生成します．これはロボットを取り巻く環境を理解するために必要な情報を得る・設定する・変更するのに必要な遠隔インタフェースを提供してくれます:
     scene = moveit_commander.PlanningSceneInterface()
 
-    ## Instantiate オブジェクト `MoveGroupCommander`_ を生成します．このオブジェクトはplanning group（ジョイント群）のためのインタフェースです．
+    ## `MoveGroupCommander`_ オブジェクトを初期化します．このオブジェクトはplanning group（関節グループ）のためのインタフェースです．
     ## このチュートリアルではplanning groupはPandaの一番はじめの腕の関節であるので，
     ## planning groupの名前は "panda_arm" としてあります．
     ## もし他のロボットを利用する際には，今回変更してあるplanning groupの名前をそのロボットの名前に変更してください．
@@ -101,7 +101,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     group_name = "panda_arm"
     move_group = moveit_commander.MoveGroupCommander(group_name)
 
-    ## Rvizで軌道を表すための
+    ## Rvizで軌道を表示するための
     ## `DisplayTrajectory`_ ROS publisher を作ります:
     display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path',
                                                    moveit_msgs.msg.DisplayTrajectory,
@@ -117,16 +117,15 @@ class MoveGroupPythonIntefaceTutorial(object):
     planning_frame = move_group.get_planning_frame()
     print "============ Planning frame: %s" % planning_frame
 
-    # We can also print the name of the end-effector link for this group:
+    # このグループのエンドエフェクタのリンクの名前を表示します:
     eef_link = move_group.get_end_effector_link()
     print "============ End effector link: %s" % eef_link
 
-    # We can get a list of all the groups in the robot:
+    # ロボットのすべてのグループのリストを取得します:
     group_names = robot.get_group_names()
     print "============ Available Planning Groups:", robot.get_group_names()
 
-    # Sometimes for debugging it is useful to print the entire state of the
-    # robot:
+    # ロボットの現在状態を表示しておくとて，デバッグがしやすくなります．
     print "============ Printing robot state"
     print robot.get_current_state()
     print ""
@@ -153,9 +152,9 @@ class MoveGroupPythonIntefaceTutorial(object):
     ##
     ## 目標関節角度への計画
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ## Pandaのゼロ・コンフィギュレーションは，特異姿勢 <https://www.quora.com/Robotics-What-is-meant-by-kinematic-singularity>_ になった際に起こります．
+    ## Pandaのゼロ・コンフィギュレーションは， `特異姿勢 <https://www.quora.com/Robotics-What-is-meant-by-kinematic-singularity>`_ になった際に起こります．
     ## なので，まずはこの姿勢を回避するようにPandaを動かします．
-    # We can get the joint values from the group and adjust some of the values:
+    # 関節角をグループから取得し，それらのいくつかを調整します:
     joint_goal = move_group.get_current_joint_values()
     joint_goal[0] = 0
     joint_goal[1] = -pi/4
@@ -165,11 +164,11 @@ class MoveGroupPythonIntefaceTutorial(object):
     joint_goal[5] = pi/3
     joint_goal[6] = 0
 
-    # The go command can be called with joint values, poses, or without any
-    # parameters if you have already set the pose or joint target for the group
+    # goコマンドは関節角や姿勢を引数に取って実行するか，予めグループの姿勢や関節のパラメータを設定しておけば，
+    # 引数なしで実行することもできます．
     move_group.go(joint_goal, wait=True)
 
-    # Calling ``stop()`` ensures that there is no residual movement
+    # stop() を呼び出すことで，残りの動作がないことを保証します
     move_group.stop()
 
     ## END_SUB_TUTORIAL
@@ -203,8 +202,8 @@ class MoveGroupPythonIntefaceTutorial(object):
     plan = move_group.go(wait=True)
     # stop() を呼び出すことで，残りの動作がないことを保証します．
     move_group.stop()
-    # It is always good to clear your targets after planning with poses.
-    # Note: there is no equivalent function for clear_joint_value_targets()
+    # 姿勢を計画したら毎回ターゲットを消すようにしましょう.
+    # Note: clear_joint_value_targets() と同じような関数は他にありません
     move_group.clear_pose_targets()
 
     ## END_SUB_TUTORIAL
@@ -227,32 +226,31 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## 直動軌道
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ## エンドエフェクタの経路座標を明示することで直接直動軌道を計画することができます．
-    ## もし，Python シェルを使って対話的に実行する場合には， set scale = 1.0 と設定してください．
+    ## もし，Python シェルを使って対話的に実行する場合には, ``scale = 1.0`` と設定してください．
     ##
     waypoints = []
 
     wpose = move_group.get_current_pose().pose
-    wpose.position.z -= scale * 0.1  # First move up (z)
-    wpose.position.y += scale * 0.2  # and sideways (y)
+    wpose.position.z -= scale * 0.1  # はじめにはｚ方向に振り上げ
+    wpose.position.y += scale * 0.2  # そしてｙ軸と水平に動く
     waypoints.append(copy.deepcopy(wpose))
 
-    wpose.position.x += scale * 0.1  # Second move forward/backwards in (x)
+    wpose.position.x += scale * 0.1  # 次にｘ軸に沿って前後に動く
     waypoints.append(copy.deepcopy(wpose))
 
-    wpose.position.y -= scale * 0.1  # Third move sideways (y)
+    wpose.position.y -= scale * 0.1  # 最後にｙ軸と水平に動く
     waypoints.append(copy.deepcopy(wpose))
 
-    # We want the Cartesian path to be interpolated at a resolution of 1 cm
-    # which is why we will specify 0.01 as the eef_step in Cartesian
-    # translation.  We will disable the jump threshold by setting it to 0.0,
-    # ignoring the check for infeasible jumps in joint space, which is sufficient
-    # for this tutorial.
+    # 直動動作を1cmに区切りたいため，直動動作への変換最大ステップ（ `eef_step` ）を0.01に設定しています．
+    # `jump_threshold` を0.0に設定しているのは，各ステップを飛ばさないように設定するためです．
+    # **警告：ジャンプ閾値を無効にすると，冗長関節を持つロボットの場合は予測不可能な動作を起こし，
+    # 危険な動作が起きる可能性があるので十分注意してください．
     (plan, fraction) = move_group.compute_cartesian_path(
                                        waypoints,   # waypoints to follow
                                        0.01,        # eef_step
                                        0.0)         # jump_threshold
 
-    # Note: We are just planning, not asking move_group to actually move the robot yet:
+    # Note: 今の段階ではロボットの動作を計画しただけであって，実際に動かしたわけではない:
     return plan, fraction
 
     ## END_SUB_TUTORIAL
@@ -273,7 +271,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## group.plan() method は自動的にこの作業を行ってくれるので，ここではあまり重要なことではありませんが
     ## 頭の片隅に留めておいてください（下記のコードは再度同じ経路を示しているだけです）:
     ##
-    ## `DisplayTrajectory`_ msg には trajectory_start と trajectory というメンバがあります．
+    ## `DisplayTrajectory`_ メッセージには trajectory_start と trajectory というメンバがあります．
     ## trajectory_start には通常，AttachedCollisionObjects (ロボットに取り付けた衝突物体)の情報を含む現在の
     ## ロボットの状態をコピーし，trajectory には生成したパス(軌道)をコピーします．
     display_trajectory = moveit_msgs.msg.DisplayTrajectory()
@@ -313,11 +311,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## BEGIN_SUB_TUTORIAL wait_for_scene_update
     ##
     ## 衝突の更新がされているか確かめる
-<<<<<<< HEAD
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-=======
-    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->>>>>>> c769fb158dd4c0f761a5cab60619faa7ec3f06a4
     ## 障害物メッセージの更新を実行する前にPythonノードが失敗したならば，
     ## メッセージは失われ立方体は現れません．更新されたことを確かめるには
     ## ``get_attached_objects()`` と ``get_known_object_names()`` のリストに変更があるまで待ちます．
@@ -327,23 +321,23 @@ class MoveGroupPythonIntefaceTutorial(object):
     start = rospy.get_time()
     seconds = rospy.get_time()
     while (seconds - start < timeout) and not rospy.is_shutdown():
-      # Test if the box is in attached objects
+      # 立方体が物体と触れているか確かめます
       attached_objects = scene.get_attached_objects([box_name])
       is_attached = len(attached_objects.keys()) > 0
 
-      # Test if the box is in the scene.
-      # Note that attaching the box will remove it from known_objects
+      # 立方体が環境にあるか確かめて行きます．
+      # ロボットに立方体を取り付けるとknown_objectsから削除されていることを確認してください．
       is_known = box_name in scene.get_known_object_names()
 
-      # Test if we are in the expected state
+      # ここまでの手順をしっかり踏んでいるか確認します
       if (box_is_attached == is_attached) and (box_is_known == is_known):
         return True
 
-      # Sleep so that we give other threads time on the processor
+      # 他のスレッドを更新するために待機します
       rospy.sleep(0.1)
       seconds = rospy.get_time()
 
-    # If we exited the while loop without returning then we timed out
+    # 返り値を返さずにループを抜けたら，タイムアウトなのでFalseを返します．
     return False
     ## END_SUB_TUTORIAL
 
@@ -363,7 +357,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     box_pose = geometry_msgs.msg.PoseStamped()
     box_pose.header.frame_id = "panda_leftfinger"
     box_pose.pose.orientation.w = 1.0
-    box_pose.pose.position.z = 0.07 # slightly above the end effector
+    box_pose.pose.position.z = 0.07 # エンドエフェクタから少し離す
     box_name = "box"
     scene.add_box(box_name, box_pose, size=(0.1, 0.1, 0.1))
 

--- a/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -36,9 +36,8 @@
 
 ## BEGIN_SUB_TUTORIAL imports
 ##
-## To use the Python MoveIt interfaces, we will import the `moveit_commander`_ namespace.
-## This namespace provides us with a `MoveGroupCommander`_ class, a `PlanningSceneInterface`_ class,
-## and a `RobotCommander`_ class. More on these below. We also import `rospy`_ and some messages that we will use:
+## Python MoveIt インターフェースを使うため， `moveit_commander`_ namespaceを導入します．
+## このnamespaceは `MoveGroupCommander`_ と `PlanningSceneInterface`_ ， `RobotCommander`_ のクラスを提供してくれます．更に下記で示される `rospy`_ と メッセージをインポートします:
 ##
 
 import sys
@@ -83,30 +82,27 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL setup
     ##
-    ## First initialize `moveit_commander`_ and a `rospy`_ node:
+    ## まず `moveit_commander`_ と `rospy`_ ノードを初期化します:
     moveit_commander.roscpp_initialize(sys.argv)
     rospy.init_node('move_group_python_interface_tutorial', anonymous=True)
 
-    ## Instantiate a `RobotCommander`_ object. Provides information such as the robot's
-    ## kinematic model and the robot's current joint states
+    ## オブジェクト `RobotCommander`_ を生成します． ロボットの
+    ## 運動学モデルと現在のジョイント状態の情報を提供してくれます
     robot = moveit_commander.RobotCommander()
 
-    ## Instantiate a `PlanningSceneInterface`_ object.  This provides a remote interface
-    ## for getting, setting, and updating the robot's internal understanding of the
-    ## surrounding world:
+    ## オブジェクト `PlanningSceneInterface`_ を生成します．これはロボットを取り巻く内部環境を理解するために必要な情報を得る・設定する・変更するのに必要な遠隔インタフェースを提供してくれます:
     scene = moveit_commander.PlanningSceneInterface()
 
-    ## Instantiate a `MoveGroupCommander`_ object.  This object is an interface
-    ## to a planning group (group of joints).  In this tutorial the group is the primary
-    ## arm joints in the Panda robot, so we set the group's name to "panda_arm".
-    ## If you are using a different robot, change this value to the name of your robot
-    ## arm planning group.
-    ## This interface can be used to plan and execute motions:
+    ## Instantiate aオブジェクト `MoveGroupCommander`_ を生成します．このオブジェクトはplanning group（ジョイント群）のためのインタフェースです．
+    ## このチュートリアルではplanning groupはPandaの一番はじめの腕の関節であるので，
+    ## planning groupの名前は "panda_arm" としてあります．
+    ## もし他のロボットを利用する際には，今回変更してあるplanning groupの名前をそのロボットの名前に変更してください．
+    ## このインタフェースは計画と実行をするのに用いられます:
     group_name = "panda_arm"
     move_group = moveit_commander.MoveGroupCommander(group_name)
 
-    ## Create a `DisplayTrajectory`_ ROS publisher which is used to display
-    ## trajectories in Rviz:
+    ## Rvizで軌道を表すための
+    ## `DisplayTrajectory`_ ROSパブリッシャを作ります:
     display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path',
                                                    moveit_msgs.msg.DisplayTrajectory,
                                                    queue_size=20)
@@ -115,7 +111,7 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL basic_info
     ##
-    ## Getting Basic Information
+    ## 基本情報の取得
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^
     # We can get the name of the reference frame for this robot:
     planning_frame = move_group.get_planning_frame()
@@ -155,10 +151,10 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL plan_to_joint_state
     ##
-    ## Planning to a Joint Goal
-    ## ^^^^^^^^^^^^^^^^^^^^^^^^
-    ## The Panda's zero configuration is at a `singularity <https://www.quora.com/Robotics-What-is-meant-by-kinematic-singularity>`_ so the first
-    ## thing we want to do is move it to a slightly better configuration.
+    ## ゴールジョイントへの計画
+    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ## Pandaのゼロ・コンフィグレーションは `singularity <https://www.quora.com/Robotics-What-is-meant-by-kinematic-singularity>`_ にあります．
+    ## なので私達がやりたいことは，まずPandaをより良いコンフィグレーションに移すことです．
     # We can get the joint values from the group and adjust some of the values:
     joint_goal = move_group.get_current_joint_values()
     joint_goal[0] = 0
@@ -191,10 +187,10 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL plan_to_pose
     ##
-    ## Planning to a Pose Goal
-    ## ^^^^^^^^^^^^^^^^^^^^^^^
-    ## We can plan a motion for this group to a desired pose for the
-    ## end-effector:
+    ## ゴール姿勢への計画
+    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ## 任意のエンドエフェクタの姿勢をこれらの記述で
+    ## 動作を計画することができます:
     pose_goal = geometry_msgs.msg.Pose()
     pose_goal.orientation.w = 1.0
     pose_goal.position.x = 0.4
@@ -203,7 +199,7 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     move_group.set_pose_target(pose_goal)
 
-    ## Now, we call the planner to compute the plan and execute it.
+    ## ここでは上記の計画/実行をするためのプランナを呼びます．
     plan = move_group.go(wait=True)
     # Calling `stop()` ensures that there is no residual movement
     move_group.stop()
@@ -228,11 +224,10 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL plan_cartesian_path
     ##
-    ## Cartesian Paths
-    ## ^^^^^^^^^^^^^^^
-    ## You can plan a Cartesian path directly by specifying a list of waypoints
-    ## for the end-effector to go through. If executing  interactively in a
-    ## Python shell, set scale = 1.0.
+    ## Cartesian パス
+    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ## エンドエフェクタの経路座標を明示することで直接Cartesianパスを計画することができます．
+    ## 実行する際には，Python shellでscale = 1.0にしてください．
     ##
     waypoints = []
 
@@ -272,15 +267,15 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL display_trajectory
     ##
-    ## Displaying a Trajectory
+    ## 経路の表示
     ## ^^^^^^^^^^^^^^^^^^^^^^^
-    ## You can ask RViz to visualize a plan (aka trajectory) for you. But the
-    ## group.plan() method does this automatically so this is not that useful
-    ## here (it just displays the same trajectory again):
+    ## RVizに計画 (aka trajectory) を可視化させることができます．しかし
+    ## group.plan() method は自動的にこの作業を行ってくれるので，ここではあまり重要なことではありませんが
+    ## 頭の片隅に留めておいてください（下記のコードは再度同じ経路を示しているだけです）:
     ##
-    ## A `DisplayTrajectory`_ msg has two primary fields, trajectory_start and trajectory.
-    ## We populate the trajectory_start with our current robot state to copy over
-    ## any AttachedCollisionObjects and add our plan to the trajectory.
+    ## `DisplayTrajectory`_ msg はtrajectory_start と trajectoryという２つの初期領域を持ちます．
+    ## 今回はtrajectory_startではどんなAttachedCollisionObjectsでも上書きするための
+    ## ロボットの現在の状態を示し，trajectoryでは計画を追加するようにしてあります．
     display_trajectory = moveit_msgs.msg.DisplayTrajectory()
     display_trajectory.trajectory_start = robot.get_current_state()
     display_trajectory.trajectory.append(plan)
@@ -298,14 +293,13 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL execute_plan
     ##
-    ## Executing a Plan
+    ## 計画の実行
     ## ^^^^^^^^^^^^^^^^
-    ## Use execute if you would like the robot to follow
-    ## the plan that has already been computed:
+    ## 既に計算された計画をロボットにさせたければ，execute を行ってください:
     move_group.execute(plan, wait=True)
 
-    ## **Note:** The robot's current joint state must be within some tolerance of the
-    ## first waypoint in the `RobotTrajectory`_ or ``execute()`` will fail
+    ## **アナウンス:** ロボットの現在の関節は
+    ## `RobotTrajectory`_ にある最初の中継点の間になければ， ``execute()`` は失敗に終わります．
     ## END_SUB_TUTORIAL
 
 
@@ -318,15 +312,14 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL wait_for_scene_update
     ##
-    ## Ensuring Collision Updates Are Received
+    ## 衝突の更新がされているか確かにする
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ## If the Python node dies before publishing a collision object update message, the message
-    ## could get lost and the box will not appear. To ensure that the updates are
-    ## made, we wait until we see the changes reflected in the
-    ## ``get_attached_objects()`` and ``get_known_object_names()`` lists.
-    ## For the purpose of this tutorial, we call this function after adding,
-    ## removing, attaching or detaching an object in the planning scene. We then wait
-    ## until the updates have been made or ``timeout`` seconds have passed
+    ## 障害物メッセージの更新を実行する前にPythonノードが失敗したならば，the message
+    ## メッセージは失われ立方体は現れません．更新されたことを確かにするためには
+    ## ``get_attached_objects()`` と ``get_known_object_names()`` のリストに変更がなされるまで待ちます．
+    ## このチュートリアルの目的として，このfunctionは
+    ## planningで物体を追加・除去・取り付け/外しをした後に呼び出します．
+    ## なので更新されるまでか， ``timeout`` で設定された時間が過ぎるまで待ちます．
     start = rospy.get_time()
     seconds = rospy.get_time()
     while (seconds - start < timeout) and not rospy.is_shutdown():
@@ -360,9 +353,9 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL add_box
     ##
-    ## Adding Objects to the Planning Scene
+    ## Planning系に物体を追加する
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ## First, we will create a box in the planning scene at the location of the left finger:
+    ## まずPlanning系の左指の位置に立方体を作ります:
     box_pose = geometry_msgs.msg.PoseStamped()
     box_pose.header.frame_id = "panda_leftfinger"
     box_pose.pose.orientation.w = 1.0
@@ -389,14 +382,14 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL attach_object
     ##
-    ## Attaching Objects to the Robot
+    ## ロボットに物体を取り付ける
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ## Next, we will attach the box to the Panda wrist. Manipulating objects requires the
-    ## robot be able to touch them without the planning scene reporting the contact as a
-    ## collision. By adding link names to the ``touch_links`` array, we are telling the
-    ## planning scene to ignore collisions between those links and the box. For the Panda
-    ## robot, we set ``grasping_group = 'hand'``. If you are using a different robot,
-    ## you should change this value to the name of your end effector group name.
+    ## 次に，Pandaの手首に立方体を取り付けます．物体の操作には
+    ## planningの段階で衝突として表示されていない状態で，物体に触れることができる必要があります．
+    ## 一覧に ``touch_links`` というlinkの名前を加えることで,
+    ## planning系にそれらのリンクと物体間での衝突を無視するように設定します．
+    ## Pandaロボットには， ``grasping_group = 'hand'`` を設定してあります．他のロボットを使う際には，
+    ## エンドエフェクタのgroup nameをそのロボットの名前に変更してください
     grasping_group = 'hand'
     touch_links = robot.get_link_names(group=grasping_group)
     scene.attach_box(eef_link, box_name, touch_links=touch_links)
@@ -416,9 +409,9 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL detach_object
     ##
-    ## Detaching Objects from the Robot
+    ## ロボットから物体を取り外す
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ## We can also detach and remove the object from the planning scene:
+    ## ロボットから物体を取り外し，消すことも可能です:
     scene.remove_attached_object(eef_link, name=box_name)
     ## END_SUB_TUTORIAL
 
@@ -435,13 +428,12 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## BEGIN_SUB_TUTORIAL remove_object
     ##
-    ## Removing Objects from the Planning Scene
+    ## 物体をplanning系から消す
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ## We can remove the box from the world.
+    ## 計画から物体を消すことができます．
     scene.remove_world_object(box_name)
 
-    ## **Note:** The object must be detached before we can remove it from the world
-    ## END_SUB_TUTORIAL
+    ## **アナウンス:** 物体を消す前にロボットから取り外さなければなりません．    ## END_SUB_TUTORIAL
 
     # We wait for the planning scene to update.
     return self.wait_for_state_update(box_is_attached=False, box_is_known=False, timeout=timeout)

--- a/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -313,7 +313,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## BEGIN_SUB_TUTORIAL wait_for_scene_update
     ##
     ## 衝突の更新がされているか確かにする
-    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ## 障害物メッセージの更新を実行する前にPythonノードが失敗したならば，the message
     ## メッセージは失われ立方体は現れません．更新されたことを確かにするためには
     ## ``get_attached_objects()`` と ``get_known_object_names()`` のリストに変更がなされるまで待ちます．

--- a/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/ja/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -313,7 +313,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## BEGIN_SUB_TUTORIAL wait_for_scene_update
     ##
     ## 衝突の更新がされているか確かにする
-    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ## 障害物メッセージの更新を実行する前にPythonノードが失敗したならば，the message
     ## メッセージは失われ立方体は現れません．更新されたことを確かにするためには
     ## ``get_attached_objects()`` と ``get_known_object_names()`` のリストに変更がなされるまで待ちます．


### PR DESCRIPTION
### Description

Add `ja/doc/move_group_python_interface/move_group_python_interface_tutorial.rst` translation

### For checking

```
$ ./ja/build_locally.sh
```

And the browser shows the `ja/build/html/index.html` page.
So, please check if the translation of `ja/doc/move_group_python_interface/move_group_python_interface_tutorial.html` is good.