### PR TITLE
Add move_commander_scripting translation

### DIFF
--- a/ja/doc/moveit_commander_scripting/moveit_commander_scripting_tutorial.rst
+++ b/ja/doc/moveit_commander_scripting/moveit_commander_scripting_tutorial.rst
@@ -1,55 +1,54 @@
-MoveIt Commander Scripting
+MoveIt Commanderスクリプト
 ===========================
 .. image:: moveit_commander_scripting.png
    :width: 700px
 
-The `moveit_commander <http://wiki.ros.org/moveit_commander>`_ Python package offers wrappers for the functionality provided in MoveIt. Simple interfaces are available for motion planning, computation of Cartesian paths, and pick and place. The ``moveit_commander`` package also includes a command line interface, ``moveit_commander_cmdline.py``.
+`moveit_commander <http://wiki.ros.org/moveit_commander>`_ PythonパッケージはMoveItで提供されている機能をラッパーにして提供してくれます．シンプルなインタフェースは動作計画や直動動作の算出，物体を拾ったり置いたりすることを可能にしてくれます． ``moveit_commander`` パッケージにはコマンドライン・インタフェースである ``moveit_commander_cmdline.py`` も含まれています．
 
-Getting Started
+はじめに
 ---------------
-If you haven't already done so, make sure you've completed the steps in `Getting Started <../getting_started/getting_started.html>`_.
+もしまだ済ましていなければ，まず `はじめに <../getting_started/getting_started.html>`_ から始めてください.
 
-Starting RViz and the Command Line Tool
----------------------------------------
-Open two shells. Start RViz and wait for everything to finish loading in the first shell: ::
+RVizとコマンドラインツールを立ち上げる
+----------------------------------------------------------------
+まずshellを２つ立ち上げ，一方はRVizを起動しすべて完了するまで待ちます: ::
 
   roslaunch panda_moveit_config demo.launch
 
-Now initiate the ``moveit_commander`` interface in another shell: ::
+次に ``moveit_commander`` インタフェースをもう一つのshellで初期化します: ::
 
  rosrun moveit_commander moveit_commander_cmdline.py
 
-Using the MoveIt Commander Command Line Tool
----------------------------------------------
-The command below will start a command line interface tool that allows you to connect to a running instance of the move_group node. The first command you should type is: ::
+MoveIt Commanderコマンドラインツールを使う
+-------------------------------------------------------------------------
+下記コマンドで `move_group` ノードを初期化し，アクセス可能になるコマンドラインツールが立ち上がります．早速入力してみましょう: ::
 
  use <group name>
 
-This will connect to the move_group node for the group name you specified (in the Panda, for instance, you could connect to ``panda_arm``). You can now execute commands on that group.
-This command, ``current``, will show you the current state of your group: ::
+このコマンドにより `move_group` ノードとあなた自身が決めた名前のグループをつなげます（Pandaロボットでは， ``panda_arm`` とつながります）. これで指定したグループのコマンドを実行することができるようになります．下記の ``current`` コマンドにより， グループの現在の状態を表示できます: ::
 
  current
 
-To record that state under a specific name you can simply type: ::
+下記のように自分で決めた名前（今回は ``c`` ）にロボットの状態を記録することができます: ::
 
  rec c
 
-This will remember the current joint values of the robot group under the name ``c``. Matlab-like syntax is available for modifying joint values. The code above copies the joint values of c into a new variable named goal. We then modify the first joint of ``goal`` to ``0.2``. You may need to use a different value instead of ``0.2`` (it needs to be within your allowed bounds and not cause collisions). The ``go`` command plans a motion and executes it.
+このコマンドにより ``c`` という変数にロボットの現在の関節角を記録します．これにより，Matlabのような記法で関節角を変更することもできます． ここでは， ``goal`` という変数に先程関節角を記録した ``c`` をコピーします．その後， ``goal`` の一番目の関節の値を ``0.2`` に変更します． ``0.2`` 以外の値を設定することもできます．（ただし，限界関節角度内もしくは，非衝突範囲内に設定する必要があります）．最後に ``go`` コマンドで動作計画と実行を行います．
 
-To get the robot to move, you could type, for example: ::
+ロボットを動かすために，例えば下記のように入力することができます: ::
 
  goal = c
  goal[0] = 0.2
  go goal
 
 
-Instead of calling ``go`` you could also type: ::
+また ``go`` を呼び出す代わりに，このように入力することもできます: ::
 
  goal[0] = 0.2
  goal[1] = 0.2
  plan goal
  execute
 
-This is slightly inefficient, but the advantage is that the ``plan`` command allows you to visualize the computed motion plan in RViz before you actually issue the execute command.
+``go`` よりも記述は多いですが, ``plan`` コマンドは実行する前にRViz上で計画を表示してくれるという点で優れています．
 
-For a list of supported commands, you can type ``help``. To exit the ``moveit_commander`` interface you can type ``quit``.
+コマンドの参照をするには， ``help`` と入力してください．また， ``moveit_commander`` インタフェースを終了するには， ``quit`` と入力してください.


### PR DESCRIPTION
### Description

Add `ja/doc/moveit_commander_scripting/moveit_commander_scripting_tutorial.rst` translation

### For checking

```
$ ./ja/build_locally.sh
```

And the browser shows the `ja/build/html/index.html` page.
So, please check if the translation of `ja/doc/moveit_commander_scripting/moveit_commander_scripting_tutorial.html` is good.